### PR TITLE
Update 2017_01_01_000000_create_queue_monitor_table.php

### DIFF
--- a/migrations/2017_01_01_000000_create_queue_monitor_table.php
+++ b/migrations/2017_01_01_000000_create_queue_monitor_table.php
@@ -13,6 +13,8 @@ class CreateQueueMonitorTable extends Migration
     public function up()
     {
         Schema::create('queue_monitor', function (Blueprint $table) {
+            $table->charset = 'utf8';
+            $table->collation = 'utf8_general_ci';
             $table->increments('id');
             $table->string('job_id')->index();
             $table->string('name')->nullable();


### PR DESCRIPTION
Force charset and collation on table to stop issues with long index on job_id varchar.